### PR TITLE
[GRO] Adding undocumented API endpoint we need to use

### DIFF
--- a/lib/rsalesloft/resources/accounts.rb
+++ b/lib/rsalesloft/resources/accounts.rb
@@ -21,6 +21,10 @@ module RSalesloft::Resources
         RSalesloft::Connection.put(accounts_path(id), options)
       end
 
+      def bulk_delete(ids)
+        RSalesloft::Connection.post("bulk_delete_accounts", {ids: ids}) # undocumented but used by their frontend
+      end
+
       private 
 
       def accounts_path(id = nil)


### PR DESCRIPTION
When data was imported from Saleforce into Salesloft, both Opportunities and Accounts were copied.

Opportunities mapped 1 to 1 to CustomerApplication and in the Salesloft world they are Persons
Accounts don't map to anything.

The problem is that in Salesloft Accounts have owners (reps) and that conflicts with the ownership of Persons and that both confuses the reps and don't bring any value.

Craig, Darren and I asked Salesloft to bulk delete but they won't, so we need to do it.
They suggested selecting 100 records at a time in the UI and clicking a button to delete, but we have over 900k records.
Thus I looked how their UI was handling it and discovered this undocumented API, that we're going to use.

I tested in my machine and it worked:

![Screenshot 2025-01-02 at 12 40 04 PM](https://github.com/user-attachments/assets/26e209aa-6f46-4298-b405-31853b72ab16)

![Screenshot 2025-01-02 at 12 40 15 PM](https://github.com/user-attachments/assets/3d451d39-6c72-4b53-bbea-66d09ef2838d)

